### PR TITLE
Add video creation helper script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 captures/
-tools/
 node_modules/
 dist/

--- a/README.md
+++ b/README.md
@@ -76,15 +76,21 @@ function stopCapture360(event) {
 
 # Unarchive, Convert, and Add Metadata
 
-Unarchive the .tar files to a single folder and then convert the whole folder of images into a movie with one FFMPEG command
+You can do this manually by extracting the files and running FFMPEG yourself:
 
 ```ffmpeg -i %07d.jpg video.mp4```
 
-The “%07d” tells FFMPEG that there are 7 decimals before the “.jpg” extension in each filename. 
+The “%07d” tells FFMPEG that there are 7 decimals before the “.jpg” extension in each filename.
+
+To automate the process a script is provided in `tools/create-video.js`.  It requires `node`, `tar` and `ffmpeg` to be installed.  If the [Spatial Media Metadata Injector](https://github.com/google/spatial-media/releases) is available in your `PATH` the script will also embed the metadata automatically.
+
+Example usage:
+
+```bash
+node tools/create-video.js video.mp4 capture-*.tar
+```
 
 In tests of a 30 second capture, I've seen a 1.66GB folder of 4K 360 images compress into a single 3.12mb  4K 360 video.  A lot depends on how much movement there is in the scene, but the reductions are dramatic.
-
-Then use the [Spatial Media Metadata Injector](https://github.com/google/spatial-media/releases) to add spatial metadata and upload.
 
 ## Build and Run
 

--- a/tools/create-video.js
+++ b/tools/create-video.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+if (process.argv.length < 4) {
+  console.error('Usage: node tools/create-video.js <output.mp4> <archive.tar ...>');
+  process.exit(1);
+}
+
+const output = path.resolve(process.argv[2]);
+const archives = process.argv.slice(3);
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'j360-'));
+
+console.log(`Extracting archives to ${tmpDir}`);
+
+for (const archive of archives) {
+  const res = spawnSync('tar', ['-xf', archive, '-C', tmpDir], { stdio: 'inherit' });
+  if (res.status !== 0) {
+    console.error(`Failed to extract ${archive}`);
+    process.exit(res.status);
+  }
+}
+
+const ffmpegArgs = ['-y', '-i', path.join(tmpDir, '%07d.jpg'), output];
+console.log(`Running ffmpeg ${ffmpegArgs.join(' ')}`);
+let res = spawnSync('ffmpeg', ffmpegArgs, { stdio: 'inherit' });
+if (res.status !== 0) {
+  console.error('ffmpeg failed');
+  process.exit(res.status);
+}
+
+try {
+  const which = spawnSync('which', ['spatialmedia']);
+  if (which.status === 0) {
+    const injected = path.join(path.dirname(output), path.parse(output).name + '_360' + path.parse(output).ext);
+    const args = ['-i', output, injected];
+    console.log(`Injecting metadata: spatialmedia ${args.join(' ')}`);
+    res = spawnSync('spatialmedia', args, { stdio: 'inherit' });
+    if (res.status === 0) {
+      console.log(`Metadata injected video at ${injected}`);
+    } else {
+      console.error('Metadata injection failed');
+    }
+  } else {
+    console.log('spatialmedia not found, skipping metadata injection');
+  }
+} catch (e) {
+  console.log('spatialmedia not found, skipping metadata injection');
+}
+
+console.log('Done');
+fs.rmSync(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- add `tools/create-video.js` to convert capture archives to video
- stop ignoring `tools/` directory
- document automated video creation in README
- remove temporary folders after creating the video

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cbc5c007483289b8a7154d55e4577