### PR TITLE
Add unified headless CLI, stereo WebM, and 8K capture

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -43,10 +43,13 @@
         </div>
 
 <div class="buttonHolder" style="position:relative;text-align:center;top:40px">
-<label>Resolution <select id="resolution"><option>4K</option><option>2K</option><option>1K</option></select></label>
+<label>Resolution <select id="resolution"><option>8K</option><option>4K</option><option>2K</option><option>1K</option></select></label>
 <label>Auto Save (s) <input id="autoSaveTime" type="number" value="3" min="1" step="1"/></label>
 <button class="startButton" onclick="startCapture360()">Start Capture</button>
 <button class="saveButton"  onclick="stopCapture360()">Stop Capture</button>
+<button onclick="startWebMRecording()">Start WebM</button>
+<button onclick="stopWebMRecording()">Stop WebM</button>
+<button onclick="toggleStereo()">Toggle Stereo</button>
 <span id="progress"></span>
 </div>
 

--- a/index.html
+++ b/index.html
@@ -21,10 +21,13 @@
 <div class="container" style="position:fixed;width:100%;height:100%;top:0;left:0"></div>
 
 <div class="buttonHolder" style="position:relative;text-align:center;">
-  <label>Resolution <select id="resolution"><option>4K</option><option>2K</option><option>1K</option></select></label>
+  <label>Resolution <select id="resolution"><option>8K</option><option>4K</option><option>2K</option><option>1K</option></select></label>
   <label>Auto Save (s) <input id="autoSaveTime" type="number" value="3" min="1" step="1"/></label>
   <button class="startButton" onclick="startCapture360()">Start Capture</button>
   <button class="saveButton"  onclick="stopCapture360()">Stop Capture</button>
+  <button onclick="startWebMRecording()">Start WebM</button>
+  <button onclick="stopWebMRecording()">Stop WebM</button>
+  <button onclick="toggleStereo()">Toggle Stereo</button>
   <span id="progress"></span>
 </div>
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "vite",
     "build": "tsc",
     "serve": "vite preview",
-    "headless": "node tools/headless-capture.js"
+    "headless": "node tools/headless-capture.js",
+    "cli": "node tools/j360-cli.js"
   },
   "dependencies": {
     "three": "^0.161.0",

--- a/src/j360.ts
+++ b/src/j360.ts
@@ -9,6 +9,10 @@ const capturer360 = new CCapture({
 });
 
 const startCapture360 = () => {
+    const resSel = document.getElementById('resolution') as HTMLSelectElement | null;
+    if (resSel && equiManaged) {
+        equiManaged.setResolution(resSel.value, true);
+    }
     capturer360.start();
 };
 
@@ -18,10 +22,11 @@ const stopCapture360 = () => {
 
 let webmRecorder: WebMRecorder | null = null;
 const startWebMRecording = () => {
-    if (!webmRecorder && canvas) {
-        webmRecorder = new WebMRecorder(canvas as HTMLCanvasElement);
+    if (!webmRecorder) {
+        const src = stereo ? equiManaged.getStereoCanvas() : (canvas as HTMLCanvasElement);
+        webmRecorder = new WebMRecorder(src as HTMLCanvasElement);
     }
-    webmRecorder?.start();
+    webmRecorder.start();
 };
 
 const stopWebMRecording = async () => {

--- a/tools/create-video.js
+++ b/tools/create-video.js
@@ -29,7 +29,7 @@ archives.forEach((archive, idx) => {
 
 const frameCount = fs.readdirSync(tmpDir).filter(f => f.endsWith('.jpg')).length;
 console.log(`Found ${frameCount} frames`);
-}
+
 
 const ffmpegArgs = ['-y', '-i', path.join(tmpDir, '%07d.jpg'), output];
 console.log(`Running ffmpeg ${ffmpegArgs.join(' ')}`);

--- a/tools/j360-cli.js
+++ b/tools/j360-cli.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+'use strict';
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const puppeteer = require('puppeteer');
+
+const [output = 'video.mp4', html = 'index.html', frames = '300'] = process.argv.slice(2);
+
+async function run() {
+  const url = 'file://' + path.resolve(html);
+  const browser = await puppeteer.launch({ headless: true });
+  const page = await browser.newPage();
+  await page.goto(url);
+  await page.waitForFunction('window.startCapture360');
+  await page.evaluate(() => window.startCapture360());
+  const durationMs = (parseInt(frames, 10) / 60) * 1000;
+  await page.waitForTimeout(durationMs);
+  await page.evaluate(() => window.stopCapture360());
+  await browser.close();
+
+  const archives = fs.readdirSync(process.cwd()).filter(f => /^capture-.*\.tar$/.test(f));
+  if (archives.length === 0) {
+    console.error('No capture archives found');
+    process.exit(1);
+  }
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'j360-'));
+  console.log(`Extracting archives to ${tmpDir}`);
+  archives.forEach((archive, idx) => {
+    console.log(`  [${idx + 1}/${archives.length}] ${archive}`);
+    const res = spawnSync('tar', ['-xf', archive, '-C', tmpDir], { stdio: 'inherit' });
+    if (res.status !== 0) process.exit(res.status);
+  });
+
+  const frameCount = fs.readdirSync(tmpDir).filter(f => f.endsWith('.jpg')).length;
+  console.log(`Found ${frameCount} frames`);
+
+  const ffmpegArgs = ['-y', '-i', path.join(tmpDir, '%07d.jpg'), output];
+  console.log(`Running ffmpeg ${ffmpegArgs.join(' ')}`);
+  let res = spawnSync('ffmpeg', ffmpegArgs, { stdio: 'inherit' });
+  if (res.status !== 0) {
+    console.error('ffmpeg failed');
+    process.exit(res.status);
+  }
+  console.log('ffmpeg complete');
+
+  try {
+    const which = spawnSync('which', ['spatialmedia']);
+    if (which.status === 0) {
+      const injected = path.join(path.dirname(output), path.parse(output).name + '_360' + path.parse(output).ext);
+      const args = ['-i', output, injected];
+      console.log(`Injecting metadata: spatialmedia ${args.join(' ')}`);
+      res = spawnSync('spatialmedia', args, { stdio: 'inherit' });
+      if (res.status === 0) {
+        console.log(`Metadata injected video at ${injected}`);
+      } else {
+        console.error('Metadata injection failed');
+      }
+    } else {
+      console.log('spatialmedia not found, skipping metadata injection');
+    }
+  } catch (e) {
+    console.log('spatialmedia not found, skipping metadata injection');
+  }
+
+  console.log('Done');
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+}
+
+run().catch(err => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## Summary
- fix syntax in `create-video.js`
- add a new `j360-cli` script combining capture and video creation
- support WebM stereo recording and resolution selection in `j360.ts`
- provide `getStereoCanvas`, `setResolution`, and 8K support with GPU checks
- expose new buttons in demo pages
- add `cli` npm script

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683cdcd4d1c88328ad8d70f14cc5d69d