### PR TITLE
Add JPEG worker, CLI enhancements, and WebXR preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,16 +82,39 @@ Call `startWebMRecording()` and `stopWebMRecording()` to record the canvas
 to a WebM file using WebCodecs. When stopped a WebM file will download
 automatically eliminating the external `ffmpeg` step.
 
+Use `captureFrameAsync()` to grab a single JPEG without blocking the main
+thread. The encoding work happens in a Web Worker so interactive scenes stay
+smooth even at high resolutions.
+
 ## Headless Rendering
 
 Run `npm run headless` to launch a Puppeteer instance that captures a scene
 and invokes `tools/create-video.js` to build a video without any browser
 interaction.
 
+### Command Line Interface
+
+`node tools/j360-cli.js [options] [output] [html]`
+
+The CLI now accepts options for resolution, stereo mode, frame count, and
+direct WebM output. Example:
+
+```bash
+node tools/j360-cli.js --resolution 4K --frames 600 --stereo output.mp4 demo.html
+```
+
+Use `--webm` to record directly to WebM instead of capturing JPEG frames.
+
 ## Stereo 360° Capture
 
 Toggle stereo mode at runtime with `toggleStereo()`. When enabled the output
 frames contain left and right eye views side‑by‑side for VR playback.
+
+### WebXR Preview
+
+Use the "Enter VR" button to view the scene in a compatible headset before
+exporting. This is useful for verifying stereo alignment and overall scene
+composition.
 
 # Unarchive, Convert, and Add Metadata
 

--- a/index.html
+++ b/index.html
@@ -28,6 +28,8 @@
   <button onclick="startWebMRecording()">Start WebM</button>
   <button onclick="stopWebMRecording()">Stop WebM</button>
   <button onclick="toggleStereo()">Toggle Stereo</button>
+  <button onclick="captureFrameAsync()">Capture Frame</button>
+  <button onclick="enterVR()">Enter VR</button>
   <span id="progress"></span>
 </div>
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -5,5 +5,14 @@ interface Window {
   stopCapture360: () => void;
   startWebMRecording: () => void;
   stopWebMRecording: () => Promise<void>;
+  stopWebMRecordingForCli: () => Promise<ArrayBuffer | null>;
   toggleStereo: () => void;
+  captureFrameAsync: () => Promise<void>;
+  enterVR: () => void;
 }
+
+interface Navigator {
+  xr?: any;
+}
+
+type XRSession = any;


### PR DESCRIPTION
## Summary
- integrate convertWorker in j360.ts to capture JPEGs asynchronously
- expose new functions for CLI and VR support
- enhance command line script with options for resolution, stereo, and WebM output
- add VR and capture buttons to the demo page
- document CLI usage and WebXR preview

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683d1834ab0c8328a605d58f1af26dbd