### PR TITLE
Off-thread cubemap conversion and audio capture

### DIFF
--- a/src/equirectWorker.ts
+++ b/src/equirectWorker.ts
@@ -1,0 +1,67 @@
+
+const vertexShader = `
+attribute vec3 position;
+attribute vec2 uv;
+
+uniform mat4 projectionMatrix;
+uniform mat4 modelViewMatrix;
+
+varying vec2 vUv;
+
+void main()  {
+        vUv = vec2( 1.- uv.x, uv.y );
+        gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );
+}`;
+
+const fragmentShader = `
+precision mediump float;
+
+uniform samplerCube map;
+
+varying vec2 vUv;
+
+#define M_PI 3.1415926535897932384626433832795
+
+void main()  {
+        vec2 uv = vUv;
+        float longitude = uv.x * 2. * M_PI - M_PI + M_PI / 2.;
+        float latitude = uv.y * M_PI;
+        vec3 dir = vec3(
+                - sin( longitude ) * sin( latitude ),
+                cos( latitude ),
+                - cos( longitude ) * sin( latitude )
+        );
+        normalize( dir );
+        gl_FragColor = vec4( textureCube( map, dir ).rgb, 1. );
+}`;
+
+self.onmessage = async (e: MessageEvent) => {
+  const { faces, width, height } = e.data as { faces: ImageBitmap[]; width: number; height: number };
+  const canvas = new OffscreenCanvas(width, height);
+  const renderer = new THREE.WebGLRenderer({ canvas });
+  const material = new THREE.RawShaderMaterial({
+    uniforms: { map: { value: null } },
+    vertexShader,
+    fragmentShader,
+    side: THREE.DoubleSide
+  });
+  const scene = new THREE.Scene();
+  const quad = new THREE.Mesh(new THREE.PlaneGeometry(width, height), material);
+  scene.add(quad);
+  const camera = new THREE.OrthographicCamera(width / -2, width / 2, height / 2, height / -2, -10000, 10000);
+  const output = new THREE.WebGLRenderTarget(width, height, {
+    minFilter: THREE.LinearFilter,
+    magFilter: THREE.LinearFilter,
+    wrapS: THREE.ClampToEdgeWrapping,
+    wrapT: THREE.ClampToEdgeWrapping,
+    format: THREE.RGBAFormat,
+    type: THREE.UnsignedByteType
+  });
+  const texture = new THREE.CubeTexture(faces);
+  texture.needsUpdate = true;
+  material.uniforms.map.value = texture;
+  renderer.render(scene, camera, output, true);
+  const pixels = new Uint8Array(4 * width * height);
+  renderer.readRenderTargetPixels(output, 0, 0, width, height, pixels);
+  self.postMessage({ buffer: pixels.buffer }, [pixels.buffer]);
+};

--- a/src/j360.ts
+++ b/src/j360.ts
@@ -90,9 +90,9 @@ export class J360App {
   };
 
   private captureFrameAsync = () => {
-    return new Promise<void>((resolve, reject) => {
+    return new Promise<void>(async (resolve, reject) => {
       if (!this.equiManaged) return resolve();
-      this.equiManaged.preBlob(this.equiManaged.cubeCamera, this.camera, this.scene);
+      await this.equiManaged.preBlobAsync(this.equiManaged.cubeCamera, this.camera, this.scene);
       const { width, height, ctx } = this.equiManaged;
       const data = ctx.getImageData(0, 0, width, height).data;
       this.jpegWorker.onmessage = (e: MessageEvent) => {

--- a/test/j360-cli.test.js
+++ b/test/j360-cli.test.js
@@ -1,19 +1,5 @@
 const assert = require('assert');
-const { parseArgs } = require('node:util');
-
-function parse(argv) {
-  const parsed = parseArgs({
-    args: argv,
-    options: {
-      frames: { type: 'string', short: 'f' },
-      resolution: { type: 'string', short: 'r' },
-      stereo: { type: 'boolean', short: 's' },
-      webm: { type: 'boolean', short: 'w' }
-    },
-    allowPositionals: true
-  });
-  return { values: parsed.values, positionals: parsed.positionals };
-}
+const { parse } = require('../tools/j360-cli.js');
 
 const res1 = parse(['-f','120','out.mp4']);
 assert.strictEqual(res1.values.frames, '120');


### PR DESCRIPTION
## Summary
- expose `parse` helper and guard CLI execution with `require.main`
- load `puppeteer` lazily so tests can import the CLI
- add microphone capture to `WebMRecorder`
- run cubemap-to-equirect conversion inside a new `equirectWorker`
- provide async `preBlobAsync` to use the worker and update frame capture test

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683d368514b4832885ee8885a897f537