### PR TITLE
Add signaling server, wasm encoding progress & test

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ the browser using ffmpeg.wasm. Use `--stream` with `--signal-url` to broadcast a
 WebRTC preview while capturing. Argument parsing uses Node's built in
 `parseArgs` library. When available, the CLI automatically uses `ffmpeg-static`
 and `tar-stream` instead of shelling out to external commands. A simple progress
-indicator shows capture status. Example:
+indicator shows capture status and, when using `--wasm`, encoding progress as
+well. Example:
 
 ```bash
 node tools/j360-cli.js --resolution 4K --frames 600 --stereo output.mp4 demo.html
@@ -137,8 +138,11 @@ alignment and overall scene composition.
 ### Live Streaming
 
 Call `startStreaming(url)` to send the canvas over WebRTC to a signaling server.
-`stopStreaming()` ends the connection. The CLI exposes `--stream` and
-`--signal-url` to automate remote preview from headless mode.
+`stopStreaming()` ends the connection. A simple signaling server is provided in
+`tools/signaling-server.js` and can be started with `npm run signaling`. Use its
+URL with `--signal-url` or `startStreaming()` to preview remotely. The CLI
+exposes `--stream` and `--signal-url` to automate remote preview from headless
+mode.
 
 # Unarchive, Convert, and Add Metadata
 

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "test": "node test/j360-cli.test.js",
+    "test": "node test/j360-cli.test.js && node test/ffmpeg-encoder.test.js",
     "serve": "vite preview",
     "headless": "node tools/headless-capture.js",
-    "cli": "node tools/j360-cli.js"
+    "cli": "node tools/j360-cli.js",
+    "signaling": "node tools/signaling-server.js"
   },
   "dependencies": {
     "three": "^0.161.0",

--- a/src/FfmpegEncoder.ts
+++ b/src/FfmpegEncoder.ts
@@ -15,8 +15,14 @@ export class FfmpegEncoder {
     this.frames.push(data);
   }
 
-  async encode(): Promise<Uint8Array> {
+  async encode(onProgress?: (percent: number) => void): Promise<Uint8Array> {
     const { ffmpeg, fps, format } = this;
+    if (onProgress) {
+      ffmpeg.setProgress(({ ratio }) => {
+        const pct = Math.min(100, Math.round(ratio * 100));
+        onProgress(pct);
+      });
+    }
     for (let i = 0; i < this.frames.length; i++) {
       ffmpeg.FS('writeFile', `${i}.jpg`, this.frames[i]);
     }

--- a/src/j360.ts
+++ b/src/j360.ts
@@ -74,9 +74,9 @@ export class J360App {
     }
   };
 
-  private stopWasmRecordingForCli = async () => {
+  private stopWasmRecordingForCli = async (progress?: (p: number) => void) => {
     if (!this.ffmpegEncoder) return null;
-    const data = await this.ffmpegEncoder.encode();
+    const data = await this.ffmpegEncoder.encode(progress);
     this.ffmpegEncoder = null;
     return data.buffer;
   };

--- a/test/ffmpeg-encoder.test.js
+++ b/test/ffmpeg-encoder.test.js
@@ -1,0 +1,35 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const ts = require('typescript');
+
+const src = fs.readFileSync(path.join(__dirname, '../src/FfmpegEncoder.ts'), 'utf8');
+const js = ts.transpileModule(src, { compilerOptions: { module: ts.ModuleKind.CommonJS } }).outputText;
+const m = { exports: {} };
+const Module = module.constructor;
+const mod = new Module();
+mod._compile(js, 'FfmpegEncoder.js');
+const { FfmpegEncoder } = mod.exports;
+
+const dummyFrame = new Uint8Array([0xff,0xd8,0xff,0xd9]);
+
+const encoder = new FfmpegEncoder(60, 'mp4');
+(encoder).ffmpeg = {
+  isLoaded: () => true,
+  setProgress: () => {},
+  FS(cmd, name, data) {
+    if (!this.store) this.store = {};
+    if (cmd === 'writeFile') this.store[name] = data;
+    if (cmd === 'readFile') return Uint8Array.from([0,0,0,0,0x66,0x74,0x79,0x70]);
+    if (cmd === 'unlink') delete this.store[name];
+  },
+  async run() {}
+};
+
+encoder.addFrame(dummyFrame);
+encoder.addFrame(dummyFrame);
+(async () => {
+  const data = await encoder.encode();
+  assert.ok(data[4] === 0x66 && data[5] === 0x74 && data[6] === 0x79 && data[7] === 0x70);
+  console.log('ffmpeg encoder test ok');
+})();

--- a/tools/j360-cli.ts
+++ b/tools/j360-cli.ts
@@ -101,7 +101,13 @@ async function run() {
   }
 
   if (useWasm) {
-    const buffer = await page.evaluate(() => (window as any).stopWasmRecordingForCli());
+    await page.exposeFunction('ffmpegProgress', (p: number) => {
+      process.stdout.write(`\rEncoding ${p}%`);
+    });
+    const buffer = await page.evaluate(() =>
+      (window as any).stopWasmRecordingForCli((p: number) => (window as any).ffmpegProgress(p))
+    );
+    process.stdout.write('\rEncoding 100%\n');
     await browser.close();
     if (!buffer) throw new Error('No video data received');
     fs.writeFileSync(output, Buffer.from(buffer));

--- a/tools/signaling-server.js
+++ b/tools/signaling-server.js
@@ -1,0 +1,82 @@
+const http = require('http');
+const crypto = require('crypto');
+
+const clients = new Set();
+
+function acceptKey(key) {
+  return crypto
+    .createHash('sha1')
+    .update(key + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11')
+    .digest('base64');
+}
+
+function frame(data) {
+  const json = Buffer.from(data);
+  const len = json.length;
+  let header;
+  if (len < 126) {
+    header = Buffer.from([0x81, len]);
+  } else {
+    header = Buffer.from([0x81, 126, len >> 8, len & 0xff]);
+  }
+  return Buffer.concat([header, json]);
+}
+
+function unframe(buffer) {
+  const len = buffer[1] & 0x7f;
+  let offset = 2;
+  if (len === 126) {
+    offset = 4;
+  }
+  const mask = buffer.slice(offset, offset + 4);
+  offset += 4;
+  const data = buffer.slice(offset, offset + len);
+  const out = Buffer.alloc(len);
+  for (let i = 0; i < len; i++) {
+    out[i] = data[i] ^ mask[i % 4];
+  }
+  return out.toString();
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'POST') {
+    let body = '';
+    req.on('data', chunk => (body += chunk));
+    req.on('end', () => {
+      for (const ws of clients) {
+        ws.write(frame(body));
+      }
+      res.writeHead(200);
+      res.end('ok');
+    });
+  } else {
+    res.writeHead(404);
+    res.end();
+  }
+});
+
+server.on('upgrade', (req, socket) => {
+  const key = req.headers['sec-websocket-key'];
+  const accept = acceptKey(key);
+  socket.write(
+    'HTTP/1.1 101 Switching Protocols\r\n' +
+      'Upgrade: websocket\r\n' +
+      'Connection: Upgrade\r\n' +
+      `Sec-WebSocket-Accept: ${accept}\r\n` +
+      '\r\n'
+  );
+  clients.add(socket);
+  socket.on('data', data => {
+    const msg = unframe(data);
+    for (const ws of clients) {
+      if (ws !== socket) ws.write(frame(msg));
+    }
+  });
+  socket.on('close', () => clients.delete(socket));
+  socket.on('end', () => clients.delete(socket));
+});
+
+const port = process.env.PORT || 3000;
+server.listen(port, () => {
+  console.log(`Signaling server listening on http://localhost:${port}`);
+});


### PR DESCRIPTION
## Summary
- implement a lightweight WebRTC signaling server
- expose `npm run signaling` script
- report progress during ffmpeg.wasm encoding
- display encoding progress in CLI
- add unit test for `FfmpegEncoder`
- document the signaling server and progress output

## Testing
- `npm test` *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_683d85bb48d8832898e56ba85dee206f