### PR TITLE
Implement WebGPU equirect, streaming ffmpeg.wasm, and HLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ smooth even at high resolutions.
 
 When WebGPU is available the library can output equirectangular frames at
 **16K** and **12K** resolutions. The converter automatically selects WebGPU when
-these ultra high resolutions are requested.
+these ultra high resolutions are requested and now uses a compute shader for
+fast cubemap projection.
 
 ## Headless Rendering
 
@@ -113,6 +114,11 @@ WebRTC preview while capturing. Argument parsing uses Node's built in
 and `tar-stream` instead of shelling out to external commands. A simple progress
 indicator shows capture status and, when using `--wasm`, encoding progress as
 well. Example:
+
+Use `--incremental` with `--wasm` to encode video in small chunks to reduce
+memory usage. For live previews an HLS server can be launched automatically with
+`--hls`, and frames will stream to `http://localhost:8000/hls/out.m3u8` during
+capture.
 
 ```bash
 node tools/j360-cli.js --resolution 4K --frames 600 --stereo output.mp4 demo.html

--- a/src/FfmpegEncoder.ts
+++ b/src/FfmpegEncoder.ts
@@ -3,7 +3,9 @@ import { createFFmpeg, fetchFile } from '@ffmpeg/ffmpeg';
 export class FfmpegEncoder {
   private ffmpeg = createFFmpeg({ log: true });
   private frames: Uint8Array[] = [];
-  constructor(private fps = 60, private format: 'mp4' | 'webm' = 'mp4') {}
+  private chunks: Uint8Array[] = [];
+  private chunkSize = 60;
+  constructor(private fps = 60, private format: 'mp4' | 'webm' = 'mp4', private incremental = false) {}
 
   async init() {
     if (!this.ffmpeg.isLoaded()) {
@@ -13,6 +15,25 @@ export class FfmpegEncoder {
 
   addFrame(data: Uint8Array) {
     this.frames.push(data);
+    if (this.incremental && this.frames.length >= this.chunkSize) {
+      return this.encodeChunk();
+    }
+  }
+
+  private async encodeChunk() {
+    const { ffmpeg, fps, format } = this;
+    for (let i = 0; i < this.frames.length; i++) {
+      ffmpeg.FS('writeFile', `${i}.jpg`, this.frames[i]);
+    }
+    const out = `chunk${this.chunks.length}.${format}`;
+    await ffmpeg.run('-framerate', String(fps), '-i', '%d.jpg', '-pix_fmt', 'yuv420p', out);
+    const data = ffmpeg.FS('readFile', out);
+    ffmpeg.FS('unlink', out);
+    for (let i = 0; i < this.frames.length; i++) {
+      ffmpeg.FS('unlink', `${i}.jpg`);
+    }
+    this.frames = [];
+    this.chunks.push(data);
   }
 
   async encode(onProgress?: (percent: number) => void): Promise<Uint8Array> {
@@ -23,17 +44,46 @@ export class FfmpegEncoder {
         onProgress(pct);
       });
     }
-    for (let i = 0; i < this.frames.length; i++) {
-      ffmpeg.FS('writeFile', `${i}.jpg`, this.frames[i]);
+    if (this.incremental) {
+      if (this.frames.length) {
+        await this.encodeChunk();
+      }
+      if (this.chunks.length === 1) {
+        const data = this.chunks[0];
+        this.chunks = [];
+        return data;
+      }
+      for (let i = 0; i < this.chunks.length; i++) {
+        ffmpeg.FS('writeFile', `chunk${i}.${format}`, this.chunks[i]);
+      }
+      let list = '';
+      for (let i = 0; i < this.chunks.length; i++) {
+        list += `file chunk${i}.${format}\n`;
+      }
+      ffmpeg.FS('writeFile', 'concat.txt', list);
+      const out = `out.${format}`;
+      await ffmpeg.run('-f', 'concat', '-safe', '0', '-i', 'concat.txt', '-c', 'copy', out);
+      const data = ffmpeg.FS('readFile', out);
+      ffmpeg.FS('unlink', out);
+      ffmpeg.FS('unlink', 'concat.txt');
+      for (let i = 0; i < this.chunks.length; i++) {
+        ffmpeg.FS('unlink', `chunk${i}.${format}`);
+      }
+      this.chunks = [];
+      return data;
+    } else {
+      for (let i = 0; i < this.frames.length; i++) {
+        ffmpeg.FS('writeFile', `${i}.jpg`, this.frames[i]);
+      }
+      const out = `out.${format}`;
+      await ffmpeg.run('-framerate', String(fps), '-i', '%d.jpg', '-pix_fmt', 'yuv420p', out);
+      const data = ffmpeg.FS('readFile', out);
+      ffmpeg.FS('unlink', out);
+      for (let i = 0; i < this.frames.length; i++) {
+        ffmpeg.FS('unlink', `${i}.jpg`);
+      }
+      this.frames = [];
+      return data;
     }
-    const out = `out.${format}`;
-    await ffmpeg.run('-framerate', String(fps), '-i', '%d.jpg', '-pix_fmt', 'yuv420p', out);
-    const data = ffmpeg.FS('readFile', out);
-    ffmpeg.FS('unlink', out);
-    for (let i = 0; i < this.frames.length; i++) {
-      ffmpeg.FS('unlink', `${i}.jpg`);
-    }
-    this.frames = [];
-    return data;
   }
 }

--- a/src/equirect-webgpu.wgsl
+++ b/src/equirect-webgpu.wgsl
@@ -1,0 +1,19 @@
+@group(0) @binding(0) var samp : sampler;
+@group(0) @binding(1) var src : texture_cube<f32>;
+@group(0) @binding(2) var dst : texture_storage_2d<rgba8unorm, write>;
+
+@compute @workgroup_size(8,8)
+fn main(@builtin(global_invocation_id) id : vec3<u32>) {
+  let dims = textureDimensions(dst);
+  if (id.x >= dims.x || id.y >= dims.y) { return; }
+  let width = f32(dims.x);
+  let height = f32(dims.y);
+  let u = (f32(id.x) + 0.5) / width;
+  let v = (f32(id.y) + 0.5) / height;
+  let longitude = u * 6.283185307179586 - 3.141592653589793 + 1.5707963267948966;
+  let latitude = v * 3.141592653589793;
+  var dir = vec3<f32>(-sin(longitude) * sin(latitude), cos(latitude), -cos(longitude) * sin(latitude));
+  dir = normalize(dir);
+  let color = textureSample(src, samp, dir);
+  textureStore(dst, vec2<i32>(i32(id.x), i32(id.y)), color);
+}

--- a/test/j360-cli.test.js
+++ b/test/j360-cli.test.js
@@ -14,4 +14,8 @@ assert.strictEqual(res3.values.fps, '30');
 assert.strictEqual(res3.values['no-audio'], true);
 assert.strictEqual(res3.values.wasm, true);
 
+const res4 = parse(['--incremental','--hls']);
+assert.strictEqual(res4.values.incremental, true);
+assert.strictEqual(res4.values.hls, true);
+
 console.log('j360-cli argument parsing ok');

--- a/tools/hls-server.js
+++ b/tools/hls-server.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+const express = require('express');
+const path = require('path');
+const fs = require('fs');
+const { spawn } = require('child_process');
+const args = require('minimist')(process.argv.slice(2));
+const fps = parseInt(args.fps || '60', 10);
+const outDir = path.resolve(process.cwd(), 'hls');
+if (!fs.existsSync(outDir)) fs.mkdirSync(outDir);
+const ffmpegPath = (() => { try { return require('ffmpeg-static'); } catch { return 'ffmpeg'; }})();
+const ffmpeg = spawn(ffmpegPath, ['-y','-f','image2pipe','-r', String(fps), '-i','-','-f','hls','-hls_time','1','-hls_list_size','4','-hls_flags','delete_segments+append_list', path.join(outDir,'out.m3u8')]);
+ffmpeg.stderr.on('data', d => process.stderr.write(d));
+const app = express();
+app.use(express.raw({ limit: '10mb', type: '*/*' }));
+app.post('/frame', (req,res) => { ffmpeg.stdin.write(req.body); res.end('ok'); });
+app.use('/hls', express.static(outDir));
+const server = app.listen(8000, () => console.log('HLS server at http://localhost:8000/hls/out.m3u8'));
+process.on('SIGINT', () => { ffmpeg.stdin.end(); ffmpeg.kill('SIGINT'); server.close(() => process.exit()); });

--- a/types/CubemapToEquirectangular.d.ts
+++ b/types/CubemapToEquirectangular.d.ts
@@ -24,10 +24,10 @@ export declare class CubemapToEquirectangular {
     getCubeCameraR(size?: number): any;
     setResolution(resolution: string, updateCamera?: boolean): void;
     attachCubeCamera(camera: any): void;
-    convert(cubeCamera: any): void;
+    convert(cubeCamera: any): Promise<void>;
     convertStereo(leftCamera: any, rightCamera: any): HTMLCanvasElement;
     getStereoCanvas(): HTMLCanvasElement;
     preBlob(cubeCamera: any, camera: any, scene: any): void;
-    update(camera: any, scene: any): void;
+    update(camera: any, scene: any): Promise<void>;
     updateStereo(camera: any, scene: any, eyeOffset?: number): HTMLCanvasElement;
 }

--- a/types/FfmpegEncoder.d.ts
+++ b/types/FfmpegEncoder.d.ts
@@ -1,7 +1,9 @@
 export declare class FfmpegEncoder {
     private ffmpeg;
     private frames;
-    constructor(fps?: number, format?: 'mp4' | 'webm');
+    private chunks;
+    private chunkSize;
+    constructor(fps?: number, format?: 'mp4' | 'webm', incremental?: boolean);
     init(): Promise<void>;
     addFrame(data: Uint8Array): void;
     encode(): Promise<Uint8Array>;

--- a/types/j360.d.ts
+++ b/types/j360.d.ts
@@ -12,13 +12,14 @@ export declare class J360App {
     private meshes;
     private stereo;
     private vrSession;
+    private hlsUrl;
     constructor();
     private startCapture360;
     private stopCapture360;
     private startWebMRecording: (fps?: number, includeAudio?: boolean) => void;
     private stopWebMRecording: () => Promise<void>;
     private stopWebMRecordingForCli: () => Promise<ArrayBuffer | null>;
-    private startWasmRecording: (fps?: number) => Promise<void>;
+    private startWasmRecording: (fps?: number, incremental?: boolean) => Promise<void>;
     private stopWasmRecordingForCli: () => Promise<ArrayBuffer | null>;
     private toggleStereo;
     private enterVR;
@@ -29,6 +30,8 @@ export declare class J360App {
     private makeSingleObject;
     private animate;
     private onWindowResize;
+    private startHLS;
+    private stopHLS;
     bindWindow(): void;
 }
 export declare const j360App: J360App;


### PR DESCRIPTION
## Summary
- implement WebGPU compute shader for converting cubemaps
- add incremental ffmpeg.wasm encoding capability
- add HLS streaming server and CLI options
- update CLI parser and tests
- document new flags and WebGPU improvements

## Testing
- `npm test` *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_683d89e4d1c88328b7a532b100f38f93