### PR TITLE
Add remote control, little planet, timelapse

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -50,6 +50,10 @@
 <button onclick="startWebMRecording()">Start WebM</button>
 <button onclick="stopWebMRecording()">Stop WebM</button>
 <button onclick="toggleStereo()">Toggle Stereo</button>
+<button onclick="downloadLittlePlanet()">Little Planet</button>
+<label>Interval (ms) <input id="intervalMs" type="number" value="0" min="100" step="100"/></label>
+<button onclick="startTimedCapture()">Start Timelapse</button>
+<button onclick="stopTimedCapture()">Stop Timelapse</button>
 <span id="progress"></span>
 </div>
 <div id="vr-overlay" style="display:none;position:absolute;top:10px;left:10px;background:rgba(0,0,0,0.5);padding:5px;color:white;">

--- a/index.html
+++ b/index.html
@@ -28,6 +28,10 @@
   <button onclick="startWebMRecording()">Start WebM</button>
   <button onclick="stopWebMRecording()">Stop WebM</button>
   <button onclick="toggleStereo()">Toggle Stereo</button>
+  <button onclick="downloadLittlePlanet()">Little Planet</button>
+  <label>Interval (ms) <input id="intervalMs" type="number" value="0" min="100" step="100"/></label>
+  <button onclick="startTimedCapture()">Start Timelapse</button>
+  <button onclick="stopTimedCapture()">Stop Timelapse</button>
   <button onclick="captureFrameAsync()">Capture Frame</button>
   <button onclick="enterVR()">Enter VR</button>
   <span id="progress"></span>

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "serve": "vite preview",
     "headless": "node tools/headless-capture.js",
     "cli": "node tools/j360-cli.js",
-    "signaling": "node tools/signaling-server.js"
+    "signaling": "node tools/signaling-server.js",
+    "remote": "node tools/remote-server.js"
   },
   "dependencies": {
     "three": "^0.161.0",

--- a/remote-control.html
+++ b/remote-control.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<body>
+<button onclick="send('start')">Start Rec</button>
+<button onclick="send('stop')">Stop Rec</button>
+<button onclick="send('stereo')">Toggle Stereo</button>
+<script>
+const ws = new WebSocket(`ws://${location.hostname}:4000`);
+function send(cmd){ ws.send(JSON.stringify({command:cmd})); }
+</script>
+</body>
+</html>

--- a/src/CubemapToEquirectangular.ts
+++ b/src/CubemapToEquirectangular.ts
@@ -429,4 +429,40 @@ void main()  {
 
     return this.convertStereo(this.cubeCamera, this.cubeCameraR);
   }
+
+  toLittlePlanet() {
+    const size = Math.min(this.width, this.height);
+    const out = document.createElement('canvas');
+    out.width = size;
+    out.height = size;
+    const ctx = out.getContext('2d');
+    if (!ctx || !this.ctx) return out;
+    const src = this.ctx.getImageData(0, 0, this.width, this.height).data;
+    const dst = ctx.createImageData(size, size);
+    const cx = size / 2;
+    const cy = size / 2;
+    const radius = size / 2;
+    for (let y = 0; y < size; y++) {
+      for (let x = 0; x < size; x++) {
+        const dx = x - cx;
+        const dy = y - cy;
+        const r = Math.sqrt(dx * dx + dy * dy);
+        if (r > radius) continue;
+        const theta = Math.atan2(dy, dx);
+        const phi = 2 * Math.atan(r / radius);
+        let u = (theta + Math.PI) / (2 * Math.PI);
+        let v = phi / Math.PI;
+        const sx = Math.min(this.width - 1, Math.max(0, Math.floor(u * this.width)));
+        const sy = Math.min(this.height - 1, Math.max(0, Math.floor(v * this.height)));
+        const si = (sy * this.width + sx) * 4;
+        const di = (y * size + x) * 4;
+        dst.data[di] = src[si];
+        dst.data[di + 1] = src[si + 1];
+        dst.data[di + 2] = src[si + 2];
+        dst.data[di + 3] = 255;
+      }
+    }
+    ctx.putImageData(dst, 0, 0);
+    return out;
+  }
 }

--- a/test/j360-cli.test.js
+++ b/test/j360-cli.test.js
@@ -19,4 +19,7 @@ assert.strictEqual(res4.values.incremental, true);
 assert.strictEqual(res4.values.hls, true);
 assert.strictEqual(res4.values['audio-file'], 'track.wav');
 
+const res5 = parse(['--interval','500']);
+assert.strictEqual(res5.values.interval, '500');
+
 console.log('j360-cli argument parsing ok');

--- a/tools/j360-cli.js
+++ b/tools/j360-cli.js
@@ -21,7 +21,8 @@ function parse(argv = process.argv.slice(2)) {
       stream: { type: 'boolean' },
       'signal-url': { type: 'string' },
       incremental: { type: 'boolean' },
-      hls: { type: 'boolean' }
+      hls: { type: 'boolean' },
+      interval: { type: 'string' }
     },
     allowPositionals: true
   });
@@ -49,6 +50,7 @@ async function run() {
   const signalUrl = values['signal-url'] || 'http://localhost:3000';
   const incremental = !!values.incremental;
   const hls = !!values.hls;
+  const interval = parseInt(values.interval || '0', 10);
 
   function checkCmd(cmd) {
     const res = spawnSync('which', [cmd]);
@@ -82,7 +84,7 @@ async function run() {
   const page = await browser.newPage();
   await page.goto(url);
   await page.waitForFunction('window.startCapture360');
-  await page.evaluate(({ resolution, stereo, useWebM, useWasm, fps, includeAudio, audioFileData, stream, signalUrl, hls, incremental }) => {
+  await page.evaluate(({ resolution, stereo, useWebM, useWasm, fps, includeAudio, audioFileData, stream, signalUrl, hls, incremental, interval }) => {
     const sel = document.getElementById('resolution');
     if (sel) sel.value = resolution;
     if (stereo) window.toggleStereo();
@@ -108,7 +110,12 @@ async function run() {
     if (hls) {
       window.startHLS('http://localhost:8000');
     }
-  }, { resolution, stereo, useWebM, useWasm, fps, includeAudio, audioFileData, stream, signalUrl, hls, incremental });
+    if (interval > 0) {
+      const input = document.getElementById('intervalMs');
+      if (input) input.value = String(interval);
+      window.startTimedCapture();
+    }
+  }, { resolution, stereo, useWebM, useWasm, fps, includeAudio, audioFileData, stream, signalUrl, hls, incremental, interval });
 
   const durationMs = (frames / fps) * 1000;
   const step = 1000;

--- a/tools/remote-server.js
+++ b/tools/remote-server.js
@@ -1,0 +1,54 @@
+const http = require('http');
+const crypto = require('crypto');
+
+const clients = new Set();
+
+function acceptKey(key){
+  return crypto.createHash('sha1').update(key + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11').digest('base64');
+}
+
+function frame(data){
+  const json = Buffer.from(data);
+  const len = json.length;
+  let header;
+  if(len < 126){ header = Buffer.from([0x81, len]); }
+  else { header = Buffer.from([0x81, 126, len >> 8, len & 0xff]); }
+  return Buffer.concat([header, json]);
+}
+
+function unframe(buf){
+  const len = buf[1] & 0x7f;
+  let offset = 2;
+  if(len === 126){ offset = 4; }
+  const mask = buf.slice(offset, offset + 4);
+  offset += 4;
+  const data = buf.slice(offset, offset + len);
+  const out = Buffer.alloc(len);
+  for(let i=0;i<len;i++){ out[i] = data[i] ^ mask[i%4]; }
+  return out.toString();
+}
+
+const server = http.createServer();
+server.on('upgrade',(req,socket)=>{
+  const key = req.headers['sec-websocket-key'];
+  const accept = acceptKey(key);
+  socket.write(
+    'HTTP/1.1 101 Switching Protocols\r\n'+
+    'Upgrade: websocket\r\n'+
+    'Connection: Upgrade\r\n'+
+    `Sec-WebSocket-Accept: ${accept}\r\n`+
+    '\r\n'
+  );
+  clients.add(socket);
+  socket.on('data',d=>{
+    const msg = unframe(d);
+    for(const c of clients){ if(c!==socket) c.write(frame(msg)); }
+  });
+  socket.on('close',()=>clients.delete(socket));
+  socket.on('end',()=>clients.delete(socket));
+});
+
+const port = process.env.PORT || 4000;
+server.listen(port,()=>{
+  console.log(`Remote server listening on http://localhost:${port}`);
+});


### PR DESCRIPTION
## Summary
- add new buttons for timelapse and little planet snapshots
- create remote control web page
- implement remote control server
- add WebSocket client and time‑lapse to `J360App`
- implement little planet projection
- support `--interval` option in CLI and tests

## Testing
- `npm test` *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_683d92e16f3c83288acc96856673d2de