### PR TITLE
Add screenshot mode and frame processor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ and `tar-stream` instead of shelling out to external commands. A simple progress
 indicator shows capture status and, when using `--wasm`, encoding progress as
 well. Example:
 
+Use `--screenshot` to save a single equirectangular JPEG and exit immediately.
+
 Use `--incremental` with `--wasm` to encode video in small chunks to reduce
 memory usage. For live previews an HLS server can be launched automatically with
 `--hls`, and frames will stream to `http://localhost:8000/hls/out.m3u8` during
@@ -147,6 +149,11 @@ Use the "Enter VR" button to view the scene in a compatible headset before
 exporting. When in VR a small on-screen overlay lets you exit or begin
 recording without removing the headset. This is useful for verifying stereo
 alignment and overall scene composition.
+
+### Frame Processing Plugins
+
+Register custom processors with `addFrameProcessor(fn)` to modify each JPEG frame
+before encoding. See `src/processors.ts` for an example grayscale implementation.
 
 ### Live Streaming
 

--- a/remote-control.html
+++ b/remote-control.html
@@ -5,6 +5,7 @@
 <button onclick="send('stop')">Stop Rec</button>
 <button onclick="send('stereo')">Toggle Stereo</button>
 <div id="status"></div>
+<progress id="progress" value="0" max="100" style="width:100%;display:none"></progress>
 <script>
 const ws = new WebSocket(`ws://${location.hostname}:4000`);
 function send(cmd){ ws.send(JSON.stringify({command:cmd})); }
@@ -12,9 +13,14 @@ ws.onmessage = e => {
   try {
     const msg = JSON.parse(e.data);
     const div = document.getElementById('status');
-    if (!div) return;
-    if (msg.status) div.textContent = msg.status;
-    if (msg.progress !== undefined) div.textContent = `${msg.mode||''} ${msg.progress}`;
+    const bar = document.getElementById('progress');
+    if (!div || !bar) return;
+    if (msg.status) { div.textContent = msg.status; bar.style.display = 'none'; }
+    if (msg.progress !== undefined) {
+      div.textContent = `${msg.mode||''} ${msg.progress}%`;
+      bar.style.display = 'block';
+      bar.value = msg.progress;
+    }
   } catch {}
 };
 </script>

--- a/src/convertWorker.ts
+++ b/src/convertWorker.ts
@@ -1,5 +1,10 @@
 self.onmessage = async (e: MessageEvent) => {
-  const { width, height, pixels } = e.data as { width: number; height: number; pixels: ArrayBuffer };
+  const { width, height, pixels, returnBuffer } = e.data as {
+    width: number;
+    height: number;
+    pixels: ArrayBuffer;
+    returnBuffer?: boolean;
+  };
   const canvas = new OffscreenCanvas(width, height);
   const ctx = canvas.getContext('2d');
   if (!ctx) {
@@ -9,6 +14,11 @@ self.onmessage = async (e: MessageEvent) => {
   const imageData = new ImageData(new Uint8ClampedArray(pixels), width, height);
   ctx.putImageData(imageData, 0, 0);
   const blob = await canvas.convertToBlob({ type: 'image/jpeg' });
-  const url = URL.createObjectURL(blob);
-  self.postMessage({ url });
+  if (returnBuffer) {
+    const buffer = await blob.arrayBuffer();
+    self.postMessage({ buffer }, [buffer]);
+  } else {
+    const url = URL.createObjectURL(blob);
+    self.postMessage({ url });
+  }
 };

--- a/src/processors.ts
+++ b/src/processors.ts
@@ -1,0 +1,17 @@
+export async function grayscale(frame: Uint8Array): Promise<Uint8Array> {
+  const blob = new Blob([frame], { type: 'image/jpeg' });
+  const bitmap = await createImageBitmap(blob);
+  const canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return frame;
+  ctx.drawImage(bitmap, 0, 0);
+  const img = ctx.getImageData(0, 0, bitmap.width, bitmap.height);
+  for (let i = 0; i < img.data.length; i += 4) {
+    const avg = (img.data[i] + img.data[i + 1] + img.data[i + 2]) / 3;
+    img.data[i] = img.data[i + 1] = img.data[i + 2] = avg;
+  }
+  ctx.putImageData(img, 0, 0);
+  const out = await canvas.convertToBlob({ type: 'image/jpeg' });
+  const buf = await out.arrayBuffer();
+  return new Uint8Array(buf);
+}

--- a/test/ffmpeg-encoder.test.js
+++ b/test/ffmpeg-encoder.test.js
@@ -13,7 +13,7 @@ const { FfmpegEncoder } = mod.exports;
 
 const dummyFrame = new Uint8Array([0xff,0xd8,0xff,0xd9]);
 
-const encoder = new FfmpegEncoder(60, 'mp4', false, false, null, true);
+const encoder = new FfmpegEncoder(60, 'mp4', false, false, null, true, []);
 (encoder).ffmpeg = {
   isLoaded: () => true,
   setProgress: () => {},
@@ -26,9 +26,9 @@ const encoder = new FfmpegEncoder(60, 'mp4', false, false, null, true);
   async run() {}
 };
 
-encoder.addFrame(dummyFrame);
-encoder.addFrame(dummyFrame);
 (async () => {
+  await encoder.addFrame(dummyFrame);
+  await encoder.addFrame(dummyFrame);
   const data = await encoder.encode();
   assert.ok(data[4] === 0x66 && data[5] === 0x74 && data[6] === 0x79 && data[7] === 0x70);
   console.log('ffmpeg encoder test ok');

--- a/test/j360-cli.test.js
+++ b/test/j360-cli.test.js
@@ -25,4 +25,7 @@ assert.strictEqual(res5.values.interval, '500');
 const res6 = parse(['--stream-encode']);
 assert.strictEqual(res6.values['stream-encode'], true);
 
+const res7 = parse(['--screenshot']);
+assert.strictEqual(res7.values.screenshot, true);
+
 console.log('j360-cli argument parsing ok');

--- a/types/FfmpegEncoder.d.ts
+++ b/types/FfmpegEncoder.d.ts
@@ -1,3 +1,4 @@
+export type FrameProcessor = (frame: Uint8Array) => Uint8Array | Promise<Uint8Array>;
 export declare class FfmpegEncoder {
     private ffmpeg;
     private frames;
@@ -6,8 +7,9 @@ export declare class FfmpegEncoder {
     private audioRec;
     private audioChunks;
     private audioData;
-    constructor(fps?: number, format?: 'mp4' | 'webm', incremental?: boolean, includeAudio?: boolean, extAudioData?: Uint8Array | null, streamEncode?: boolean);
+    constructor(fps?: number, format?: 'mp4' | 'webm', incremental?: boolean, includeAudio?: boolean, extAudioData?: Uint8Array | null, streamEncode?: boolean, processors?: FrameProcessor[]);
     init(): Promise<void>;
-    addFrame(data: Uint8Array): void;
+    addProcessor(p: FrameProcessor): void;
+    addFrame(data: Uint8Array): Promise<void>;
     encode(onProgress?: (p: number) => void): Promise<Uint8Array>;
 }

--- a/types/j360.d.ts
+++ b/types/j360.d.ts
@@ -35,6 +35,8 @@ export declare class J360App {
     private onVrSqueeze;
     private enterVR;
     private captureFrameAsync;
+    private captureFrameAsyncForCli;
+    addFrameProcessor(p: (frame: Uint8Array) => Uint8Array | Promise<Uint8Array>): void;
     private init;
     private placeObjectsAroundYou;
     private locationNames;

--- a/types/processors.d.ts
+++ b/types/processors.d.ts
@@ -1,0 +1,1 @@
+export declare function grayscale(frame: Uint8Array): Promise<Uint8Array>;


### PR DESCRIPTION
## Summary
- allow CLI to capture a single JPEG with `--screenshot`
- add a frame processor plugin API and example grayscale processor
- expose CLI screenshot capture support in compiled JS
- show progress from the capture page in a progress bar on the remote control page

## Testing
- `npm test` *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_683e6284224c8328aedc1513a9de7622