### PR TITLE
Add RTMP, AV1 and plugin CLI features

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Use `--incremental` with `--wasm` to encode video in small chunks to reduce
 memory usage. For live previews an HLS server can be launched automatically with
 `--hls`, and frames will stream to `http://localhost:8000/hls/out.m3u8` during
 capture.
+Use `--rtmp <url>` to push frames to an RTMP endpoint via a helper server at `http://localhost:8001`.
+Select AV1 encoding with `--codec av1` for smaller file sizes.
 
 ```bash
 node tools/j360-cli.js --resolution 4K --frames 600 --stereo output.mp4 demo.html
@@ -154,6 +156,7 @@ alignment and overall scene composition.
 
 Register custom processors with `addFrameProcessor(fn)` to modify each JPEG frame
 before encoding. See `src/processors.ts` for an example grayscale implementation.
+Plugins can also be loaded from the CLI with `--plugin my-filter.js`.
 
 ### Live Streaming
 

--- a/src/WebCodecsRecorder.ts
+++ b/src/WebCodecsRecorder.ts
@@ -8,7 +8,8 @@ export class WebCodecsRecorder {
     private canvas: HTMLCanvasElement,
     private fps = 60,
     private includeAudio = true,
-    private bitrate = 5_000_000
+    private bitrate = 5_000_000,
+    private codec: 'vp9' | 'av1' = 'vp9'
   ) {}
 
   async init() {
@@ -25,8 +26,9 @@ export class WebCodecsRecorder {
       },
       error: (e) => console.error(e)
     });
+    const codecStr = this.codec === 'av1' ? 'av01.0.08M.08' : 'vp09.00.10.08';
     const support = await (VideoEncoder as any).isConfigSupported({
-      codec: 'vp09.00.10.08',
+      codec: codecStr,
       width,
       height,
       bitrate: this.bitrate,

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -6,18 +6,20 @@ interface Window {
   startWebMRecording: () => void;
   stopWebMRecording: () => Promise<void>;
   stopWebMRecordingForCli: () => Promise<ArrayBuffer | null>;
-  startWebCodecsRecording: () => void;
+  startWebCodecsRecording: (fps?: number, includeAudio?: boolean, codec?: 'vp9' | 'av1') => void;
   stopWebCodecsRecording: () => Promise<void>;
   stopWebCodecsRecordingForCli: () => Promise<ArrayBuffer | null>;
   toggleStereo: () => void;
   captureFrameAsync: () => Promise<void>;
   enterVR: () => void;
-  startWasmRecording: () => void;
+  startWasmRecording: (fps?: number, incremental?: boolean, includeAudio?: boolean, audioData?: Uint8Array, streamEncode?: boolean, codec?: 'h264' | 'vp9' | 'av1') => void;
   stopWasmRecordingForCli: () => Promise<ArrayBuffer | null>;
   startStreaming: (url: string) => void;
   stopStreaming: () => void;
   startHLS: (url: string) => void;
   stopHLS: () => void;
+  startRTMP: (url: string) => void;
+  stopRTMP: () => void;
 }
 
 interface Navigator {

--- a/test/ffmpeg-encoder.test.js
+++ b/test/ffmpeg-encoder.test.js
@@ -13,7 +13,7 @@ const { FfmpegEncoder } = mod.exports;
 
 const dummyFrame = new Uint8Array([0xff,0xd8,0xff,0xd9]);
 
-const encoder = new FfmpegEncoder(60, 'mp4', false, false, null, true, []);
+const encoder = new FfmpegEncoder(60, 'mp4', false, false, null, true, 'h264', []);
 (encoder).ffmpeg = {
   isLoaded: () => true,
   setProgress: () => {},

--- a/test/j360-cli.test.js
+++ b/test/j360-cli.test.js
@@ -28,4 +28,13 @@ assert.strictEqual(res6.values['stream-encode'], true);
 const res7 = parse(['--screenshot']);
 assert.strictEqual(res7.values.screenshot, true);
 
+const res8 = parse(['--rtmp','rtmp://example']);
+assert.strictEqual(res8.values.rtmp, 'rtmp://example');
+
+const res9 = parse(['--codec','av1']);
+assert.strictEqual(res9.values.codec, 'av1');
+
+const res10 = parse(['--plugin','a.js','--plugin','b.js']);
+assert.deepStrictEqual(res10.values.plugin, ['a.js','b.js']);
+
 console.log('j360-cli argument parsing ok');

--- a/tools/rtmp-server.js
+++ b/tools/rtmp-server.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+const express = require('express');
+const path = require('path');
+const { spawn } = require('child_process');
+const args = require('minimist')(process.argv.slice(2));
+const fps = parseInt(args.fps || '60', 10);
+const url = args.url;
+if (!url) {
+  console.error('RTMP URL required via --url');
+  process.exit(1);
+}
+const ffmpegPath = (() => { try { return require('ffmpeg-static'); } catch { return 'ffmpeg'; }})();
+const ffmpeg = spawn(ffmpegPath, ['-y','-f','image2pipe','-r',String(fps),'-i','-','-c:v','libx264','-f','flv',url]);
+ffmpeg.stderr.on('data', d => process.stderr.write(d));
+const app = express();
+app.use(express.raw({ limit: '10mb', type: '*/*' }));
+app.post('/frame', (req,res) => { ffmpeg.stdin.write(req.body); res.end('ok'); });
+const server = app.listen(8001, () => console.log('RTMP proxy on http://localhost:8001 -> ' + url));
+process.on('SIGINT', () => { ffmpeg.stdin.end(); ffmpeg.kill('SIGINT'); server.close(() => process.exit()); });

--- a/types/FfmpegEncoder.d.ts
+++ b/types/FfmpegEncoder.d.ts
@@ -7,7 +7,7 @@ export declare class FfmpegEncoder {
     private audioRec;
     private audioChunks;
     private audioData;
-    constructor(fps?: number, format?: 'mp4' | 'webm', incremental?: boolean, includeAudio?: boolean, extAudioData?: Uint8Array | null, streamEncode?: boolean, processors?: FrameProcessor[]);
+    constructor(fps?: number, format?: 'mp4' | 'webm', incremental?: boolean, includeAudio?: boolean, extAudioData?: Uint8Array | null, streamEncode?: boolean, codec?: 'h264' | 'vp9' | 'av1', processors?: FrameProcessor[]);
     init(): Promise<void>;
     addProcessor(p: FrameProcessor): void;
     addFrame(data: Uint8Array): Promise<void>;

--- a/types/WebCodecsRecorder.d.ts
+++ b/types/WebCodecsRecorder.d.ts
@@ -8,7 +8,7 @@ export declare class WebCodecsRecorder {
     private audioRec;
     private audioChunks;
     private frameCount;
-    constructor(canvas: HTMLCanvasElement, fps?: number, includeAudio?: boolean, bitrate?: number);
+    constructor(canvas: HTMLCanvasElement, fps?: number, includeAudio?: boolean, bitrate?: number, codec?: 'vp9' | 'av1');
     init(): Promise<void>;
     start(): void;
     addFrame(): void;

--- a/types/j360.d.ts
+++ b/types/j360.d.ts
@@ -16,6 +16,7 @@ export declare class J360App {
     private vrSession;
     private vrHud;
     private hlsUrl;
+    private rtmpUrl;
     constructor();
     private startCapture360;
     private stopCapture360;
@@ -45,6 +46,8 @@ export declare class J360App {
     private onWindowResize;
     private startHLS;
     private stopHLS;
+    private startRTMP;
+    private stopRTMP;
     bindWindow(): void;
 }
 export declare const j360App: J360App;


### PR DESCRIPTION
## Summary
- allow specifying codec and frame processor plugins via CLI
- add RTMP streaming helper and hooks in j360 runtime
- support AV1 in WebCodecsRecorder and ffmpeg encoder
- update command line tests for new options
- document new flags in README

## Testing
- `npm test` *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_683e6f155bbc832881d38abc14f27873