### PR TITLE
Add metadata injector, HLS viewer and GPU filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ alignment and overall scene composition.
 Register custom processors with `addFrameProcessor(fn)` to modify each JPEG frame
 before encoding. See `src/processors.ts` for an example grayscale implementation.
 Plugins can also be loaded from the CLI with `--plugin my-filter.js`.
+GPU accelerated filters can be built with `createWebGLProcessor()` from `src/gpu-processors.ts` which runs custom shaders in an `OffscreenCanvas` for high performance transformations.
 
 ### Live Streaming
 
@@ -170,6 +171,10 @@ exposes `--stream` and `--signal-url` to automate remote preview from headless
 
 Open `viewer.html` in any browser to watch the WebRTC preview. The page connects to the signaling server on port 3000 and displays the incoming stream.
 
+### HLS Viewer
+
+When capturing with `--hls`, frames stream to an HLS server on port 8000. Open `hls-viewer.html` to play the generated playlist using `hls.js` while monitoring progress.
+
 ### Adaptive Resolution
 
 Enable adaptive mode with `toggleAdaptive()` or pass `--adaptive` to the CLI. When active the library lowers the resolution if frames take longer than 40ms to render and raises it again once performance recovers.
@@ -182,7 +187,7 @@ You can do this manually by extracting the files and running FFMPEG yourself:
 
 The “%07d” tells FFMPEG that there are 7 decimals before the “.jpg” extension in each filename.
 
-To automate the process a script is provided in `tools/create-video.js`.  It requires `node`, `tar` and `ffmpeg` to be installed.  If the [Spatial Media Metadata Injector](https://github.com/google/spatial-media/releases) is available in your `PATH` the script will also embed the metadata automatically.
+To automate the process a script is provided in `tools/create-video.js`.  It requires `node`, `tar` and `ffmpeg` to be installed.  The script now embeds the necessary 360° metadata directly in Node so the external Spatial Media tool is no longer required.
 
 Example usage:
 

--- a/hls-viewer.html
+++ b/hls-viewer.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<body>
+<video id="hls" controls autoplay style="width:100%;max-width:100%"></video>
+<progress id="progress" value="0" max="100" style="width:100%;display:none"></progress>
+<div id="status"></div>
+<script src="https://cdn.jsdelivr.net/npm/hls.js@1"></script>
+<script>
+const video = document.getElementById('hls');
+function play(url){
+  if(Hls.isSupported()){
+    const hls = new Hls();
+    hls.loadSource(url);
+    hls.attachMedia(video);
+  }else if(video.canPlayType('application/vnd.apple.mpegurl')){
+    video.src = url;
+  }
+}
+play('http://localhost:8000/hls/out.m3u8');
+const ws = new WebSocket(`ws://${location.hostname}:4000`);
+ws.onmessage = e => {
+  try{
+    const msg = JSON.parse(e.data);
+    const div = document.getElementById('status');
+    const bar = document.getElementById('progress');
+    if(msg.status){ div.textContent = msg.status; bar.style.display='none'; }
+    if(msg.progress!==undefined){ div.textContent = `${msg.mode||''} ${msg.progress}%`; bar.style.display='block'; bar.value=msg.progress; }
+  }catch{}
+};
+</script>
+</body>
+</html>

--- a/src/gpu-processors.ts
+++ b/src/gpu-processors.ts
@@ -1,0 +1,44 @@
+export function createWebGLProcessor(fragmentSource: string) {
+  let canvas: OffscreenCanvas | null = null;
+  let gl: WebGLRenderingContext | null = null;
+  let program: WebGLProgram | null = null;
+  const vertex = `attribute vec2 p;varying vec2 v;void main(){v=p*0.5+0.5;gl_Position=vec4(p,0,1);}`;
+  function init(width: number, height: number) {
+    canvas = new OffscreenCanvas(width, height);
+    gl = canvas.getContext('webgl');
+    if (!gl) return;
+    const vs = gl.createShader(gl.VERTEX_SHADER)!; gl.shaderSource(vs, vertex); gl.compileShader(vs);
+    const fs = gl.createShader(gl.FRAGMENT_SHADER)!; gl.shaderSource(fs, fragmentSource); gl.compileShader(fs);
+    program = gl.createProgram()!; gl.attachShader(program, vs); gl.attachShader(program, fs); gl.linkProgram(program);
+    gl.useProgram(program);
+    const buf = gl.createBuffer(); gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1,-1,1,-1,-1,1,1,1]), gl.STATIC_DRAW);
+    const loc = gl.getAttribLocation(program,'p');
+    gl.enableVertexAttribArray(loc); gl.vertexAttribPointer(loc,2,gl.FLOAT,false,0,0);
+  }
+  return async (frame: Uint8Array) => {
+    const blob = new Blob([frame], {type:'image/jpeg'});
+    const bmp = await createImageBitmap(blob);
+    if(!canvas) init(bmp.width, bmp.height);
+    if(!gl||!program||!canvas) return frame;
+    const tex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    gl.texImage2D(gl.TEXTURE_2D,0,gl.RGBA,gl.RGBA,gl.UNSIGNED_BYTE,bmp);
+    gl.drawArrays(gl.TRIANGLE_STRIP,0,4);
+    const pixels = new Uint8Array(bmp.width*bmp.height*4);
+    gl.readPixels(0,0,bmp.width,bmp.height,gl.RGBA,gl.UNSIGNED_BYTE,pixels);
+    const ctx = canvas.getContext('2d');
+    if(!ctx) return frame;
+    const imgData = new ImageData(new Uint8ClampedArray(pixels), bmp.width, bmp.height);
+    ctx.putImageData(imgData,0,0);
+    const out = await canvas.convertToBlob({type:'image/jpeg'});
+    const buf = await out.arrayBuffer();
+    return new Uint8Array(buf);
+  };
+}
+
+export const invertFilter = createWebGLProcessor(
+  'precision mediump float;varying vec2 v;uniform sampler2D t;void main(){gl_FragColor=vec4(1.0-texture2D(t,v).rgb,1.0);}'
+);

--- a/tools/create-video.js
+++ b/tools/create-video.js
@@ -53,22 +53,12 @@ if (res.status !== 0) {
 console.log('ffmpeg complete');
 
 try {
-  const which = spawnSync('which', ['spatialmedia']);
-  if (which.status === 0) {
-    const injected = path.join(path.dirname(output), path.parse(output).name + '_360' + path.parse(output).ext);
-    const args = ['-i', output, injected];
-    console.log(`Injecting metadata: spatialmedia ${args.join(' ')}`);
-    res = spawnSync('spatialmedia', args, { stdio: 'inherit' });
-    if (res.status === 0) {
-      console.log(`Metadata injected video at ${injected}`);
-    } else {
-      console.error('Metadata injection failed');
-    }
-  } else {
-    console.log('spatialmedia not found, skipping metadata injection');
-  }
+  const { injectMp4 } = require('./metadata');
+  console.log('Injecting 360 metadata');
+  injectMp4(output);
+  console.log('Metadata injected');
 } catch (e) {
-  console.log('spatialmedia not found, skipping metadata injection');
+  console.error('Metadata injection failed:', e.message);
 }
 
 console.log('Done');

--- a/tools/j360-cli.js
+++ b/tools/j360-cli.js
@@ -238,25 +238,13 @@ async function run() {
     }
     console.log('ffmpeg complete');
     try {
-        const which = (0, child_process_1.spawnSync)('which', ['spatialmedia']);
-        if (which.status === 0) {
-            const injected = path_1.default.join(path_1.default.dirname(output), path_1.default.parse(output).name + '_360' + path_1.default.parse(output).ext);
-            const args = ['-i', output, injected];
-            console.log(`Injecting metadata: spatialmedia ${args.join(' ')}`);
-            res = (0, child_process_1.spawnSync)('spatialmedia', args, { stdio: 'inherit' });
-            if (res.status === 0) {
-                console.log(`Metadata injected video at ${injected}`);
-            }
-            else {
-                console.error('Metadata injection failed');
-            }
-        }
-        else {
-            console.log('spatialmedia not found, skipping metadata injection');
-        }
+        const { injectMp4 } = require('./metadata.js');
+        console.log('Injecting 360 metadata');
+        injectMp4(output);
+        console.log('Metadata injected');
     }
     catch (e) {
-        console.log('spatialmedia not found, skipping metadata injection');
+        console.error('Metadata injection failed:', e.message);
     }
     console.log('Done');
     fs_1.default.rmSync(tmpDir, { recursive: true, force: true });

--- a/tools/j360-cli.ts
+++ b/tools/j360-cli.ts
@@ -231,22 +231,12 @@ async function run() {
   console.log('ffmpeg complete');
 
   try {
-    const which = spawnSync('which', ['spatialmedia']);
-    if (which.status === 0) {
-      const injected = path.join(path.dirname(output), path.parse(output).name + '_360' + path.parse(output).ext);
-      const args = ['-i', output, injected];
-      console.log(`Injecting metadata: spatialmedia ${args.join(' ')}`);
-      res = spawnSync('spatialmedia', args, { stdio: 'inherit' });
-      if (res.status === 0) {
-        console.log(`Metadata injected video at ${injected}`);
-      } else {
-        console.error('Metadata injection failed');
-      }
-    } else {
-      console.log('spatialmedia not found, skipping metadata injection');
-    }
+    const { injectMp4 } = require('./metadata.js');
+    console.log('Injecting 360 metadata');
+    injectMp4(output);
+    console.log('Metadata injected');
   } catch (e) {
-    console.log('spatialmedia not found, skipping metadata injection');
+    console.error('Metadata injection failed:', e.message);
   }
 
   console.log('Done');

--- a/tools/metadata.js
+++ b/tools/metadata.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+
+function injectMp4(file){
+  const data = fs.readFileSync(file);
+  const moov = data.indexOf('moov');
+  if(moov < 0) throw new Error('moov atom not found');
+  const size = data.readUInt32BE(moov - 4);
+  const end = moov - 4 + size;
+  const before = data.slice(0, end);
+  const after = data.slice(end);
+  const xml = Buffer.from(`<?xml version="1.0"?>\n<rdf:SphericalVideo xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:GSpherical="http://ns.google.com/videos/1.0/spherical/">\n<GSpherical:Spherical>true</GSpherical:Spherical>\n<GSpherical:Stitched>true</GSpherical:Stitched>\n<GSpherical:StitchingSoftware>j360 built-in</GSpherical:StitchingSoftware>\n<GSpherical:ProjectionType>equirectangular</GSpherical:ProjectionType>\n</rdf:SphericalVideo>`);
+  const uuid = Buffer.from('ffcc8263f8554d02a9e59e4a505a9c9a','hex');
+  const boxSize = Buffer.alloc(4);
+  boxSize.writeUInt32BE(8 + uuid.length + xml.length);
+  const box = Buffer.concat([boxSize, Buffer.from('uuid'), uuid, xml]);
+  const newMoov = Buffer.concat([before, box]);
+  newMoov.writeUInt32BE(size + box.length, moov - 4);
+  const out = Buffer.concat([newMoov, after]);
+  fs.writeFileSync(file, out);
+}
+
+module.exports = { injectMp4 };


### PR DESCRIPTION
## Summary
- provide built‑in 360° metadata injector for mp4
- add HLS viewer page for `--hls` streaming
- implement GPU WebGL frame processor utilities
- document new features

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683ed81625c0832884a1dd59c07c5163