### PR TITLE
Add GPU shader plugins and adaptive capture improvements

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -67,6 +67,11 @@ Key options:
 - `--hls` – stream frames to an HLS server.
 - `--rtmp <url>` – push frames to an RTMP endpoint.
 - `--screenshot` – save a single JPEG and exit.
+- `--adaptive` – enable automatic resolution switching.
+- `--min-res <1K|2K|4K|8K|12K|16K>` – lower bound for adaptive mode.
+- `--max-res <1K|2K|4K|8K|12K|16K>` – upper bound for adaptive mode.
+
+See `plugins/invert-plugin.js` for a GPU shader example usable with `--plugin`.
 
 See `tools/j360-cli.ts` for all supported flags.
 
@@ -104,7 +109,7 @@ Install `ffmpeg` on your system or ensure `ffmpeg-static` is available. The CLI 
 
 ### Can I add filters to the frames?
 
-Yes. Register a processor with `addFrameProcessor(fn)` or pass `--plugin my-filter.js` to the CLI. See `src/processors.ts` for a grayscale example.
+Yes. Register a processor with `addFrameProcessor(fn)` or pass `--plugin my-filter.js` to the CLI. See `src/processors.ts` for a grayscale example or `plugins/invert-plugin.js` for a WebGL shader filter.
 
 ## Running Tests
 

--- a/plugins/invert-plugin.js
+++ b/plugins/invert-plugin.js
@@ -1,0 +1,8 @@
+export default `
+precision mediump float;
+varying vec2 v;
+uniform sampler2D t;
+void main(){
+  vec4 c = texture2D(t, v);
+  gl_FragColor = vec4(1.0 - c.rgb, c.a);
+}`;

--- a/remote-control.html
+++ b/remote-control.html
@@ -17,7 +17,7 @@ ws.onmessage = e => {
     if (!div || !bar) return;
     if (msg.status) { div.textContent = msg.status; bar.style.display = 'none'; }
     if (msg.progress !== undefined) {
-      div.textContent = `${msg.mode||''} ${msg.progress}%`;
+      div.textContent = `${msg.mode||''} ${msg.progress}% ${msg.frame||0}f ${msg.elapsed||0}s`;
       bar.style.display = 'block';
       bar.value = msg.progress;
     }

--- a/src/j360.ts
+++ b/src/j360.ts
@@ -4,6 +4,7 @@ import { WebCodecsRecorder } from './WebCodecsRecorder';
 import { CubemapToEquirectangular } from './CubemapToEquirectangular';
 import { FfmpegEncoder } from './FfmpegEncoder';
 import { WebRTCStreamer } from './WebRTCStreamer';
+import { createWebGLProcessor } from './gpu-processors';
 import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
 import CCapture from "ccapture.js";
@@ -35,6 +36,12 @@ export class J360App {
   private frameProcessors: ((frame: Uint8Array) => Uint8Array | Promise<Uint8Array>)[] = [];
   private adaptive = false;
   private lastTime = performance.now();
+  private targetFps = 60;
+  private avgDt = 16;
+  private adaptiveMin = '1K';
+  private adaptiveMax = '16K';
+  private currentResolution = '4K';
+  private startTime = 0;
 
   constructor() {
     this.init();
@@ -45,12 +52,15 @@ export class J360App {
   private startCapture360 = () => {
     const resSel = document.getElementById('resolution') as HTMLSelectElement | null;
     if (resSel && this.equiManaged) {
+      this.currentResolution = resSel.value;
       this.equiManaged.setResolution(resSel.value, true);
     }
     this.capturer360.start();
     this.frameCount = 0;
     this.captureMode = 'ccapture';
     this.recording = true;
+    this.targetFps = 60;
+    this.startTime = performance.now();
     this.updateVrHud();
   };
 
@@ -70,6 +80,8 @@ export class J360App {
     this.frameCount = 0;
     this.captureMode = 'webm';
     this.recording = true;
+    this.targetFps = fps;
+    this.startTime = performance.now();
     this.updateVrHud();
     this.sendRemoteStatus('recording');
   };
@@ -84,6 +96,8 @@ export class J360App {
     this.frameCount = 0;
     this.captureMode = 'webcodecs';
     this.recording = true;
+    this.targetFps = fps;
+    this.startTime = performance.now();
     this.updateVrHud();
   };
 
@@ -181,13 +195,16 @@ export class J360App {
       this.frameCount = 0;
       this.captureMode = 'wasm';
       this.recording = true;
+      this.targetFps = fps;
+      this.startTime = performance.now();
     }
   };
 
   private stopWasmRecordingForCli = async (onProgress?: (p: number) => void) => {
     if (!this.ffmpegEncoder) return null;
     const data = await this.ffmpegEncoder.encode(p => {
-      this.sendRemoteStatus({ progress: p, mode: 'encoding' });
+      const elapsed = Math.floor((performance.now() - this.startTime) / 1000);
+      this.sendRemoteStatus({ progress: p, mode: 'encoding', frame: this.frameCount, elapsed });
       if (onProgress) onProgress(p);
     });
     this.ffmpegEncoder = null;
@@ -249,8 +266,20 @@ export class J360App {
     this.frameProcessors.push(p);
   }
 
+  public setAdaptiveRange(min: string, max: string) {
+    this.adaptiveMin = min;
+    this.adaptiveMax = max;
+  }
+
   private updateVrHud = () => {
-    if (this.vrHud) this.vrHud.textContent = this.recording ? 'Recording' : '';
+    if (this.vrHud) {
+      if (this.recording) {
+        const elapsed = Math.floor((performance.now() - this.startTime) / 1000);
+        this.vrHud.textContent = `REC ${this.frameCount}f ${elapsed}s`;
+      } else {
+        this.vrHud.textContent = '';
+      }
+    }
   };
 
   private onVrSelect = () => {
@@ -448,10 +477,18 @@ export class J360App {
     const dt = now - this.lastTime;
     this.lastTime = now;
     if (this.adaptive && this.equiManaged) {
-      if (dt > 40 && this.equiManaged.width > 2048) {
-        this.equiManaged.setResolution('2K', true);
-      } else if (dt < 30 && this.equiManaged.width < 4096) {
-        this.equiManaged.setResolution('4K', true);
+      const target = 1000 / this.targetFps;
+      this.avgDt = this.avgDt * 0.9 + dt * 0.1;
+      const levels = ['1K','2K','4K','8K','12K','16K'];
+      const cur = levels.indexOf(this.currentResolution);
+      const min = Math.max(0, levels.indexOf(this.adaptiveMin));
+      const max = Math.min(levels.length - 1, levels.indexOf(this.adaptiveMax));
+      if (this.avgDt > target * 1.5 && cur > min) {
+        this.currentResolution = levels[cur - 1];
+        this.equiManaged.setResolution(this.currentResolution, true);
+      } else if (this.avgDt < target * 0.8 && cur < max) {
+        this.currentResolution = levels[cur + 1];
+        this.equiManaged.setResolution(this.currentResolution, true);
       }
     }
 
@@ -470,7 +507,9 @@ export class J360App {
     }
     if (this.recording) {
       this.frameCount++;
-      this.sendRemoteStatus({ progress: this.frameCount, mode: this.captureMode });
+      const elapsed = Math.floor((performance.now() - this.startTime) / 1000);
+      this.sendRemoteStatus({ progress: this.frameCount, mode: this.captureMode, frame: this.frameCount, elapsed });
+      this.updateVrHud();
     }
 
     if (this.ffmpegEncoder) {
@@ -536,6 +575,8 @@ export class J360App {
     (window as any).stopHLS = this.stopHLS;
     (window as any).startRTMP = this.startRTMP;
     (window as any).stopRTMP = this.stopRTMP;
+    (window as any).createWebGLProcessor = createWebGLProcessor;
+    (window as any).setAdaptiveRange = (min: string, max: string) => this.setAdaptiveRange(min, max);
   }
 }
 

--- a/test/j360-cli.test.js
+++ b/test/j360-cli.test.js
@@ -40,4 +40,8 @@ assert.deepStrictEqual(res10.values.plugin, ['a.js','b.js']);
 const res11 = parse(['--adaptive']);
 assert.strictEqual(res11.values.adaptive, true);
 
+const res12 = parse(['--min-res','2K','--max-res','8K']);
+assert.strictEqual(res12.values['min-res'], '2K');
+assert.strictEqual(res12.values['max-res'], '8K');
+
 console.log('j360-cli argument parsing ok');

--- a/viewer.html
+++ b/viewer.html
@@ -2,6 +2,7 @@
 <html>
 <body>
 <video id="view" autoplay playsinline style="width:100%;max-width:100%"></video>
+<div id="status" style="position:absolute;top:10px;left:10px;background:rgba(0,0,0,0.5);color:white;padding:4px"></div>
 <script>
 const video = document.getElementById('view');
 const ws = new WebSocket(`ws://${location.hostname}:3000`);
@@ -20,6 +21,18 @@ ws.onmessage = async e => {
       ws.send(JSON.stringify({ answer }));
     } else if (msg.candidate) {
       await pc.addIceCandidate(msg.candidate);
+    }
+  } catch {}
+};
+const status = document.getElementById('status');
+const ws2 = new WebSocket(`ws://${location.hostname}:4000`);
+ws2.onmessage = e => {
+  try {
+    const msg = JSON.parse(e.data);
+    if (msg.progress !== undefined) {
+      status.textContent = `${msg.mode||''} ${msg.progress}% ${msg.frame||0}f ${msg.elapsed||0}s`;
+    } else if (msg.status) {
+      status.textContent = msg.status;
     }
   } catch {}
 };


### PR DESCRIPTION
## Summary
- support GPU-powered plugins via `createWebGLProcessor`
- expose adaptive resolution range flags in the CLI
- show capture metrics in VR HUD and remote pages
- add sample invert shader plugin
- update docs and tests for new CLI options

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68402244f90083288d96066790094c14