### PR TITLE
Update diagrams and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This project shows how to export 4K resolution 360 Videos and Photos from inside of Three.js scenes.
+This project shows how to export high resolution 360° videos and photos from inside of Three.js scenes. When WebGPU is available the library can generate up to 16K output.
 
 The process is described in this blog post: https://medium.com/p/788226f2c75f
 

--- a/docs/DIAGRAMS.md
+++ b/docs/DIAGRAMS.md
@@ -60,12 +60,13 @@ Methods shown above are defined in [src/j360.ts](../src/j360.ts).
 ```mermaid
 timeline
     title Typical Workflow
-    2024 : Clone repository
-    2024 : npm install
-    2024 : npm run dev
-    2024 : Record demo
-    2024 : Run j360-cli.js
-    2024 : Convert with create-video.js
+    2025 : Clone repository
+    2025 : npm install
+    2025 : npm run dev
+    2025 : Record demo
+    2025 : Run j360-cli.js
+    2025 : Convert with create-video.js
+    2025 : Release v2.0
 ```
 
 ## Gitgraph
@@ -76,5 +77,6 @@ gitGraph
     commit id: "recorder" tag: "recording"
     commit id: "stream" tag: "streaming"
     commit id: "cli" tag: "cli"
+    commit id: "webgpu" tag: "v2"
 ```
 


### PR DESCRIPTION
## Summary
- revise README intro to mention 16K output
- refresh DIAGRAMS timeline for 2025 and add WebGPU commit

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684101c8fb60832881ec009b8028be6c