### PR TITLE
Add capture mode selector and recording controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,11 @@ Install dependencies with `npm install` and start a development server:
 npm run dev
 ```
 
+Open `http://localhost:5173` in your browser. Select a capture mode from the
+"Capture" drop‑down then click **Start Recording**. The page shows a running
+frame count and elapsed time. Options that your browser doesn't support are
+automatically disabled.
+
 Build the bundled assets:
 
 ```bash

--- a/demo.html
+++ b/demo.html
@@ -44,6 +44,12 @@
 
 <div class="buttonHolder" style="position:relative;text-align:center;top:40px">
 <label>Resolution <select id="resolution"><option>16K</option><option>12K</option><option>8K</option><option>4K</option><option>2K</option><option>1K</option></select></label>
+<label>Capture <select id="capture-mode">
+    <option value="ccapture">Images (CCapture)</option>
+    <option value="webm">WebM</option>
+    <option value="webcodecs">WebCodecs</option>
+    <option value="wasm">MP4 (WASM)</option>
+  </select></label>
 <label>Auto Save (s) <input id="autoSaveTime" type="number" value="3" min="1" step="1"/></label>
 <button class="startButton" onclick="startCapture360()">Start Capture</button>
 <button class="saveButton"  onclick="stopCapture360()">Stop Capture</button>

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -29,7 +29,7 @@ Start the development server:
 npm run dev
 ```
 
-Visit `http://localhost:5173` to open the demo scene. Use the on‑screen buttons to begin recording or toggle stereo mode. The interface exposes resolution and capture options.
+Visit `http://localhost:5173` to open the demo scene. Choose a capture mode from the "Capture" selector and click **Start Recording**. A progress label shows captured frames and elapsed time. Unsupported options are disabled automatically based on browser capabilities.
 
 ## Building and Serving
 

--- a/index.html
+++ b/index.html
@@ -22,11 +22,15 @@
 
 <div class="buttonHolder" style="position:relative;text-align:center;">
   <label>Resolution <select id="resolution"><option>16K</option><option>12K</option><option>8K</option><option>4K</option><option>2K</option><option>1K</option></select></label>
+  <label>Capture <select id="capture-mode">
+      <option value="ccapture">Images (CCapture)</option>
+      <option value="webm">WebM</option>
+      <option value="webcodecs">WebCodecs</option>
+      <option value="wasm">MP4 (WASM)</option>
+    </select></label>
   <label>Auto Save (s) <input id="autoSaveTime" type="number" value="3" min="1" step="1"/></label>
-  <button class="startButton" onclick="startCapture360()">Start Capture</button>
-  <button class="saveButton"  onclick="stopCapture360()">Stop Capture</button>
-  <button onclick="startWebMRecording()">Start WebM</button>
-  <button onclick="stopWebMRecording()">Stop WebM</button>
+  <button class="startButton" onclick="startRecording()">Start Recording</button>
+  <button class="saveButton"  onclick="stopRecording()">Stop Recording</button>
   <button onclick="toggleStereo()">Toggle Stereo</button>
   <button onclick="downloadLittlePlanet()">Little Planet</button>
   <label>Interval (ms) <input id="intervalMs" type="number" value="0" min="100" step="100"/></label>
@@ -38,7 +42,7 @@
 </div>
 <div id="vr-overlay" style="display:none;position:absolute;top:10px;left:10px;background:rgba(0,0,0,0.5);padding:5px;color:white;">
   <button onclick="enterVR()">Exit VR</button>
-  <button onclick="startCapture360()">Record</button>
+  <button onclick="startRecording()">Record</button>
   <div id="vr-hud"></div>
 </div>
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -7,6 +7,9 @@ interface Window {
   startWebCodecsRecording: (fps?: number, includeAudio?: boolean, codec?: 'vp9' | 'av1') => void;
   stopWebCodecsRecording: () => Promise<void>;
   stopWebCodecsRecordingForCli: () => Promise<ArrayBuffer | null>;
+  startRecording: () => void;
+  stopRecording: () => Promise<void>;
+  stopWasmRecording: () => Promise<void>;
   toggleStereo: () => void;
   captureFrameAsync: () => Promise<void>;
   enterVR: () => void;

--- a/types/j360.d.ts
+++ b/types/j360.d.ts
@@ -49,6 +49,9 @@ export declare class J360App {
     private stopHLS;
     private startRTMP;
     private stopRTMP;
+    private startRecording;
+    private stopRecording;
+    private stopWasmRecording;
     bindWindow(): void;
 }
 export declare const j360App: J360App;


### PR DESCRIPTION
## Summary
- add `capture-mode` selector to the demo pages
- implement `startRecording`/`stopRecording` and new `stopWasmRecording`
- show recording progress in the UI
- disable unsupported capture options based on browser features
- document new UI controls and feature detection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841215f228883288c82ffdb4b6a98a8