### PR TITLE
Apply shared theme to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ The app will capture a batch every N seconds, according to the autoSaveTime para
 
 Clone the repository and serve its files using a webserver of your choice.
 
+All example pages now include `styles/theme.css` which provides a shared color
+palette and responsive layout. Customize this file to adjust the look and feel.
+
 
 [index.html](index.html) contains simple test shapes.  moving the camera during capture has no effect.
 

--- a/admin.html
+++ b/admin.html
@@ -3,17 +3,12 @@
 <head>
   <title>J360 Admin</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <link rel="stylesheet" href="styles/theme.css" />
   <script type="module" src="./src/j360.ts"></script>
-  <style>
-    body { margin:0; overflow:hidden; }
-    .container { position:fixed; top:0; left:0; width:100%; height:100%; }
-    #controls { position:relative; background:white; padding:8px; text-align:center; }
-    #status { padding:4px; }
-  </style>
 </head>
 <body>
-  <div class="container"></div>
-  <div id="controls">
+  <div class="container fullscreen"></div>
+  <div id="controls" class="control-panel">
     <label>Resolution
       <select id="resolution">
         <option>16K</option><option>12K</option><option>8K</option>
@@ -56,7 +51,7 @@
     <button onclick="startCapture()">Start</button>
     <button onclick="stopCapture()">Stop</button>
   </div>
-  <div id="status">Idle</div>
+  <div id="status" class="status">Idle</div>
   <script>
     let currentMode = '';
     function startCapture() {

--- a/dashboard.html
+++ b/dashboard.html
@@ -4,20 +4,13 @@
   <meta charset="UTF-8" />
   <title>J360 Dashboard</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
+  <link rel="stylesheet" href="styles/theme.css" />
   <script type="module" src="./src/j360.ts"></script>
-  <style>
-    body { margin:0; font-family:sans-serif; }
-    .container { position:fixed; top:0; left:0; width:100%; height:100%; }
-    #panel { position:relative; padding:8px; background:#fff; display:flex; flex-wrap:wrap; gap:8px; justify-content:center; }
-    #panel label { white-space:nowrap; }
-    #status { text-align:center; padding:4px; }
-    video { width:100%; max-height:40vh; display:block; margin-bottom:8px; }
-  </style>
 </head>
-<body style="overflow:hidden;">
+<body>
   <video id="preview" autoplay playsinline></video>
-  <div class="container"></div>
-  <div id="panel">
+  <div class="container fullscreen"></div>
+  <div id="panel" class="control-panel">
     <label>Resolution
       <select id="resolution">
         <option>16K</option><option>12K</option><option>8K</option>
@@ -47,10 +40,10 @@
     <button onclick="captureFrameAsync()">Capture Frame</button>
     <button onclick="enterVR()">Enter VR</button>
     <span id="progress-text"></span>
-    <progress id="progress-bar" style="width:100%;display:none"></progress>
+    <progress id="progress-bar" class="progress-bar"></progress>
   </div>
-  <div id="status"></div>
-  <div id="vr-overlay" style="display:none;position:absolute;top:10px;left:10px;background:rgba(0,0,0,0.5);padding:5px;color:white;">
+  <div id="status" class="status"></div>
+  <div id="vr-overlay" class="overlay">
     <button onclick="enterVR()">Exit VR</button>
     <button onclick="startRecording()">Record</button>
     <div id="vr-hud"></div>

--- a/demo.html
+++ b/demo.html
@@ -4,28 +4,7 @@
         <title>three.js webgl - physically based shading</title>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
-        <style>
-            body {
-                color: #fff;
-                font-family: Monospace;
-                font-size: 13px;
-                text-align: center;
-                font-weight: bold;
-
-                background-color: #000;
-                margin: 0px;
-                overflow: hidden;
-            }
-
-            #info {
-                position: absolute;
-                width: 100%;
-                text-align: center;
-                padding: 5px;
-            }
-
-            a { color: skyblue; }
-        </style>
+        <link rel="stylesheet" href="styles/theme.css" />
         <script>
  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -38,11 +17,10 @@
     </head>
 
     <body>
-        <div id="info">
+        <div id="info" class="info-banner">
             <a href="http://threejs.org" target="_blank">three.js</a> - webgl physically based shading testbed
         </div>
-
-<div class="buttonHolder" style="position:relative;text-align:center;top:40px">
+<div class="buttonHolder control-panel mt-40">
 <label>Resolution <select id="resolution"><option>16K</option><option>12K</option><option>8K</option><option>4K</option><option>2K</option><option>1K</option></select></label>
 <label>Capture <select id="capture-mode">
     <option value="ccapture">Images (CCapture)</option>
@@ -61,9 +39,9 @@
 <button onclick="startTimedCapture()">Start Timelapse</button>
 <button onclick="stopTimedCapture()">Stop Timelapse</button>
 <span id="progress-text"></span>
-<progress id="progress-bar" style="width:100%;display:none"></progress>
+<progress id="progress-bar" class="progress-bar"></progress>
 </div>
-<div id="vr-overlay" style="display:none;position:absolute;top:10px;left:10px;background:rgba(0,0,0,0.5);padding:5px;color:white;">
+<div id="vr-overlay" class="overlay">
   <button onclick="enterVR()">Exit VR</button>
   <button onclick="startCapture360()">Record</button>
   <div id="vr-hud"></div>

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -33,6 +33,8 @@ npm run dev
 
 Visit `http://localhost:5173` to open the demo scene. Choose a capture mode from the "Capture" selector and click **Start Recording**. A progress label and bar show captured frames and elapsed time. Unsupported options are disabled automatically based on browser capabilities.
 
+All HTML examples include a common stylesheet at `styles/theme.css` for a consistent layout. Modify this file to change colors or spacing across pages.
+
 ## Building and Serving
 
 To create a production build:

--- a/hls-viewer.html
+++ b/hls-viewer.html
@@ -1,9 +1,12 @@
 <!DOCTYPE html>
 <html>
+<head>
+<link rel="stylesheet" href="styles/theme.css" />
+</head>
 <body>
-<video id="hls" controls autoplay style="width:100%;max-width:100%"></video>
-<progress id="progress" value="0" max="100" style="width:100%;display:none"></progress>
-<div id="status"></div>
+<video id="hls" controls autoplay class="preview"></video>
+<progress id="progress" value="0" max="100" class="progress-bar"></progress>
+<div id="status" class="status"></div>
 <script src="https://cdn.jsdelivr.net/npm/hls.js@1"></script>
 <script>
 const video = document.getElementById('hls');

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
 <title>j360</title>
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no"/>
+<link rel="stylesheet" href="styles/theme.css" />
 <!-- bundled script -->
 <script type="module" src="./src/j360.ts"></script>
 
@@ -16,11 +17,11 @@
   ga('send', 'pageview');
 </script>
 </head>
-<body style="overflow:hidden;margin:0;padding:0">
+<body>
 
-<div class="container" style="position:fixed;width:100%;height:100%;top:0;left:0"></div>
+<div class="container fullscreen"></div>
 
-<div class="buttonHolder" style="position:relative;text-align:center;">
+<div class="buttonHolder control-panel">
   <label>Resolution <select id="resolution"><option>16K</option><option>12K</option><option>8K</option><option>4K</option><option>2K</option><option>1K</option></select></label>
   <label>Capture <select id="capture-mode">
       <option value="ccapture">Images (CCapture)</option>
@@ -39,9 +40,9 @@
   <button onclick="captureFrameAsync()">Capture Frame</button>
   <button onclick="enterVR()">Enter VR</button>
   <span id="progress-text"></span>
-  <progress id="progress-bar" style="width:100%;display:none"></progress>
+  <progress id="progress-bar" class="progress-bar"></progress>
 </div>
-<div id="vr-overlay" style="display:none;position:absolute;top:10px;left:10px;background:rgba(0,0,0,0.5);padding:5px;color:white;">
+<div id="vr-overlay" class="overlay">
   <button onclick="enterVR()">Exit VR</button>
   <button onclick="startRecording()">Record</button>
   <div id="vr-hud"></div>

--- a/remote-control.html
+++ b/remote-control.html
@@ -1,11 +1,14 @@
 <!DOCTYPE html>
 <html>
-<body>
+<head>
+<link rel="stylesheet" href="styles/theme.css" />
+</head>
+<body class="control-panel">
 <button onclick="send('start')">Start Rec</button>
 <button onclick="send('stop')">Stop Rec</button>
 <button onclick="send('stereo')">Toggle Stereo</button>
 <div id="status"></div>
-<progress id="progress" value="0" max="100" style="width:100%;display:none"></progress>
+<progress id="progress" value="0" max="100" class="progress-bar"></progress>
 <script>
 const ws = new WebSocket(`ws://${location.hostname}:4000`);
 function send(cmd){ ws.send(JSON.stringify({command:cmd})); }

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -1,0 +1,98 @@
+/* Basic theme for J360 example pages */
+:root {
+  --bg-color: #f4f4f4;
+  --panel-bg: #ffffff;
+  --text-color: #333;
+  --accent-color: #1e88e5;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica,
+    Arial, sans-serif;
+  background: var(--bg-color);
+  color: var(--text-color);
+}
+
+button,
+select,
+input {
+  font-size: 1rem;
+  padding: 0.4em 0.8em;
+}
+
+.fullscreen {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.control-panel {
+  position: relative;
+  padding: 8px;
+  background: var(--panel-bg);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: center;
+  text-align: center;
+}
+
+.status {
+  padding: 4px;
+  text-align: center;
+}
+
+.overlay {
+  display: none;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  background: rgba(0, 0, 0, 0.5);
+  color: white;
+  padding: 5px;
+}
+
+.progress-bar {
+  width: 100%;
+  display: none;
+}
+
+.viewer-progress {
+  position: absolute;
+  top: 40px;
+  left: 10px;
+  width: calc(100% - 20px);
+}
+
+video.preview {
+  width: 100%;
+  max-height: 40vh;
+  display: block;
+  margin-bottom: 8px;
+}
+
+.mt-40 {
+  margin-top: 40px;
+}
+
+.info-banner {
+  position: absolute;
+  width: 100%;
+  text-align: center;
+  padding: 5px;
+}
+
+a {
+  color: var(--accent-color);
+}
+
+@media (max-width: 600px) {
+  .control-panel {
+    flex-direction: column;
+  }
+}

--- a/viewer.html
+++ b/viewer.html
@@ -1,9 +1,12 @@
 <!DOCTYPE html>
 <html>
+<head>
+<link rel="stylesheet" href="styles/theme.css" />
+</head>
 <body>
-<video id="view" autoplay playsinline style="width:100%;max-width:100%"></video>
-<div id="status" style="position:absolute;top:10px;left:10px;background:rgba(0,0,0,0.5);color:white;padding:4px"></div>
-<progress id="progress-bar" value="0" max="100" style="position:absolute;top:40px;left:10px;width:calc(100% - 20px);display:none"></progress>
+<video id="view" autoplay playsinline class="preview"></video>
+<div id="status" class="overlay"></div>
+<progress id="progress-bar" value="0" max="100" class="progress-bar viewer-progress"></progress>
 <script>
 const video = document.getElementById('view');
 const ws = new WebSocket(`ws://${location.hostname}:3000`);


### PR DESCRIPTION
## Summary
- add `styles/theme.css` with modern palette and responsive layout
- clean up inline styles in example HTML and link to the new stylesheet
- document theming in README and usage docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684164248ae483289284ca15211b9d5c